### PR TITLE
News pin publish

### DIFF
--- a/src/migrations/1661505886498-remove_name_add_title_required.ts
+++ b/src/migrations/1661505886498-remove_name_add_title_required.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class removeNameAddTitleRequired1661505886498
+  implements MigrationInterface
+{
+  name = 'removeNameAddTitleRequired1661505886498';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "news" DROP COLUMN "name"`);
+    await queryRunner.query(
+      `UPDATE "news" SET "title"='please add title' WHERE "title" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "news" ALTER COLUMN "title" SET NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "news" ALTER COLUMN "title" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "news" ADD "name" character varying NOT NULL`,
+    );
+  }
+}

--- a/src/migrations/1661508763753-add_news_status_and_pinned_fields.ts
+++ b/src/migrations/1661508763753-add_news_status_and_pinned_fields.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class addNewsStatusAndPinnedFields1661508763753 implements MigrationInterface {
+    name = 'addNewsStatusAndPinnedFields1661508763753'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "news" ADD "pinned" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`CREATE TYPE "public"."news_state_enum" AS ENUM('draft', 'published', 'reviewed')`);
+        await queryRunner.query(`ALTER TABLE "news" ADD "state" "public"."news_state_enum" NOT NULL DEFAULT 'draft'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "news" DROP COLUMN "state"`);
+        await queryRunner.query(`DROP TYPE "public"."news_state_enum"`);
+        await queryRunner.query(`ALTER TABLE "news" DROP COLUMN "pinned"`);
+    }
+
+}

--- a/src/news/dto/create-news.input.ts
+++ b/src/news/dto/create-news.input.ts
@@ -9,7 +9,7 @@ export class CreateNewsInput {
   // exampleField: number;
   // @Field({ description: 'News name' })
   // name: string;
-  @Field({ description: 'News title', nullable: true })
+  @Field({ description: 'News title' })
   title: string;
   // @Field({ description: 'News publish date' })
   @Field({ description: 'News content' })

--- a/src/news/dto/create-news.input.ts
+++ b/src/news/dto/create-news.input.ts
@@ -1,15 +1,16 @@
 import { InputType, Int, Field } from '@nestjs/graphql';
 import { Upload } from 'src/common/scalars/upload.scalar';
+import { NewsState } from '../entities/news.entity';
 // import GraphQLUpload from 'graphql-upload';
 
 @InputType()
 export class CreateNewsInput {
   // @Field(() => Int, { description: 'Example field (placeholder)' })
   // exampleField: number;
-  @Field({ description: 'News name' })
-  name: string;
+  // @Field({ description: 'News name' })
+  // name: string;
   @Field({ description: 'News title', nullable: true })
-  title?: string;
+  title: string;
   // @Field({ description: 'News publish date' })
   @Field({ description: 'News content' })
   content: string;
@@ -27,6 +28,10 @@ export class CreateNewsInput {
   source?: string;
   @Field({ description: 'News Image source', nullable: true })
   imgSource?: string;
+  @Field({ description: 'Is news pinned?', nullable: true })
+  pinned?: boolean;
+  @Field({ description: 'News Status', nullable: true })
+  state?: NewsState;
 }
 
 @InputType()

--- a/src/news/entities/news.entity.ts
+++ b/src/news/entities/news.entity.ts
@@ -1,4 +1,4 @@
-import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { ObjectType, Field, Int, registerEnumType } from '@nestjs/graphql';
 import { NewsComment } from 'src/comments/entities/comment.entity';
 import { CreatorBaseEntity } from 'src/common/entities/base.entity';
 import { pathFinderMiddleware } from 'src/common/middlewares/pathfinder.middleware';
@@ -31,6 +31,16 @@ export class NewsCategory extends CreatorBaseEntity {
   news: News[];
 }
 
+export enum NewsState {
+  DRAFT = 'draft',
+  PUBLISHED = 'published',
+  REVIWED = 'reviewed',
+}
+
+registerEnumType(NewsState, {
+  name: 'NewsState',
+});
+
 @ObjectType()
 @Entity()
 export class News {
@@ -38,13 +48,13 @@ export class News {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Field({ description: 'News name' })
-  @Column()
-  name: string;
+  // @Field({ description: 'News name' })
+  // @Column()
+  // name: string;
 
-  @Field({ description: 'News title', nullable: true })
-  @Column({ nullable: true })
-  title?: string;
+  @Field({ description: 'News title' })
+  @Column()
+  title: string;
 
   @Field({ description: 'News publishedAt', nullable: true })
   @Column({ nullable: true })
@@ -104,6 +114,13 @@ export class News {
   @Column({ nullable: true })
   imgSource?: string;
 
+  @Field({ description: 'Is news pinned?' })
+  @Column({ default: false })
+  pinned: boolean;
+
+  @Field(() => NewsState, { description: 'News state' })
+  @Column({ type: 'enum', enum: NewsState, default: NewsState.DRAFT })
+  state: NewsState;
   // @Field(() => [UserLikesNews], { description: 'News likes', nullable: true })
   @OneToMany(() => UserLikesNews, (likes) => likes.news, {
     nullable: true,

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -168,6 +168,7 @@ export class NewsService {
       take: limit,
       skip: offset,
       order: {
+        pinned: 'DESC',
         createdAt: 'DESC',
       },
     });

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -16,6 +16,7 @@ import {
   News,
   NewsCategory,
   NewsImage,
+  NewsState,
   UserLikesNews,
 } from './entities/news.entity';
 import { uploadFileStream } from 'src/common/utils/upload';
@@ -81,7 +82,7 @@ export class NewsService {
 
     const newsData: News = await this.newsRepository.save({
       ...newsInputData,
-      publishedAt: new Date(),
+      publishedAt: newsInput.state === NewsState.PUBLISHED ? new Date() : null,
       createdAt: new Date(),
       updatedAt: new Date(),
       createdBy: user, //TODO: get user from jwt
@@ -290,6 +291,9 @@ export class NewsService {
       } = {
         ...news,
         ...newsInputData,
+        publishedAt:
+          news.publishedAt ||
+          (updateNewsInput.state === NewsState.PUBLISHED ? new Date() : null),
         updatedAt: new Date(),
         updatedBy: user,
         // images: ['guur'],

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -162,6 +162,7 @@ export class NewsService {
         category: true,
       },
       where: {
+        state: NewsState.PUBLISHED,
         category: {
           id: filterNewsInput.category,
         },

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -53,7 +53,7 @@ input CreateNewsInput {
   tags: [String!]
 
   """News title"""
-  title: String
+  title: String!
 }
 
 input CreateNewsReplyInput {

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -39,12 +39,15 @@ input CreateNewsInput {
   """News link"""
   link: String
 
-  """News name"""
-  name: String!
+  """Is news pinned?"""
+  pinned: Boolean
   singleImage: Upload
 
   """News source"""
   source: String
+
+  """News Status"""
+  state: String
 
   """News tags"""
   tags: [String!]
@@ -172,8 +175,8 @@ type News {
   """News link"""
   link: String
 
-  """News name"""
-  name: String!
+  """Is news pinned?"""
+  pinned: Boolean!
 
   """News publishedAt"""
   publishedAt: DateTime
@@ -184,11 +187,14 @@ type News {
   """News source"""
   source: String
 
+  """News state"""
+  state: NewsState!
+
   """News tags"""
   tags: [NewsTaggit!]
 
   """News title"""
-  title: String
+  title: String!
 
   """News updatedAt"""
   updatedAt: DateTime!
@@ -352,6 +358,12 @@ type NewsReplyPageInfo {
 type NewsResponse {
   page: NewsConnection!
   pageData: PageData
+}
+
+enum NewsState {
+  DRAFT
+  PUBLISHED
+  REVIWED
 }
 
 type NewsTaggit {
@@ -573,12 +585,15 @@ input UpdateNewsInput {
   """News link"""
   link: String
 
-  """News name"""
-  name: String
+  """Is news pinned?"""
+  pinned: Boolean
   singleImage: Upload
 
   """News source"""
   source: String
+
+  """News Status"""
+  state: String
 
   """News tags"""
   tags: [String!]


### PR DESCRIPTION
Fix #65
Fix #66 
The logic to set publish date may require work in future. The current logic doesn't handle the case if the news state is changed from published to other states like DRAFT from PUBLISHED.