### PR TITLE
Added search feature for yellowpages for both app and admin

### DIFF
--- a/src/schema.gql
+++ b/src/schema.gql
@@ -297,6 +297,7 @@ input FilterYellowPagesInput {
   """Yellow Pages category"""
   category: Int
   district: Int
+  is_emergency: Boolean
   province: Int
 
   """Search query for yellow pages"""

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -298,6 +298,9 @@ input FilterYellowPagesInput {
   category: Int
   district: Int
   province: Int
+
+  """Search query for yellow pages"""
+  searchQuery: String
 }
 
 """GeoJSON Point"""

--- a/src/yellow-pages/dto/filter-yellowpages.input.ts
+++ b/src/yellow-pages/dto/filter-yellowpages.input.ts
@@ -19,4 +19,7 @@ export class FilterYellowPagesInput extends PartialType(
 
   @Field(() => Int, { nullable: true })
   district?: number;
+
+  @Field(() => String, { description:'Search query for yellow pages', nullable:true})
+  searchQuery?: string;
 }

--- a/src/yellow-pages/dto/filter-yellowpages.input.ts
+++ b/src/yellow-pages/dto/filter-yellowpages.input.ts
@@ -20,6 +20,12 @@ export class FilterYellowPagesInput extends PartialType(
   @Field(() => Int, { nullable: true })
   district?: number;
 
-  @Field(() => String, { description:'Search query for yellow pages', nullable:true})
+  @Field(() => Boolean, { nullable: true })
+  is_emergency: boolean;
+
+  @Field(() => String, {
+    description: 'Search query for yellow pages',
+    nullable: true,
+  })
   searchQuery?: string;
 }

--- a/src/yellow-pages/yellow-pages.resolver.ts
+++ b/src/yellow-pages/yellow-pages.resolver.ts
@@ -53,7 +53,6 @@ import {
   DistrictService,
   YellowPagesEmailService,
 } from './yellow-pages.service';
-import { ErrorLoggerInterceptor } from 'src/common/interceptors/errorlogger.interceptor';
 import { UseGuards, UseInterceptors } from '@nestjs/common';
 import { Roles } from 'src/common/decorators/roles.decorator';
 import { Role } from 'src/common/enum/role.enum';
@@ -64,7 +63,7 @@ import {
   FilterYellowPagesInput,
 } from './dto/filter-yellowpages.input';
 
-@Resolver()
+@Resolver(() => YellowPages)
 @Roles(Role.Admin, Role.SuperAdmin)
 @UseGuards(RolesGuard)
 export class YellowPagesResolver {
@@ -89,10 +88,11 @@ export class YellowPagesResolver {
     filterYellowPagesInput?: FilterYellowPagesInput,
   ): Promise<YellowPagesResponse> {
     const { limit, offset } = args.pagingParams();
-    const [yellowPages, count] = await this.yellowPagesService.findAll(
+    const [yellowPages, count] = await this.yellowPagesService.findAllSearch(
       limit,
       offset,
       filterYellowPagesInput,
+      true,
     );
 
     const page = connectionFromArraySlice(yellowPages, args, {
@@ -111,8 +111,9 @@ export class YellowPagesResolver {
     @Args('filterYellowPagesInput', { nullable: true })
     filterYellowPagesInput?: FilterYellowPagesInput,
   ): Promise<YellowPagesAdminResponse> {
-    const [yellowpages, count] = await this.yellowPagesService.adminFindAll(
-      args,
+    const [yellowpages, count] = await this.yellowPagesService.findAllSearch(
+      args.take,
+      args.skip,
       filterYellowPagesInput,
     );
     return { data: yellowpages, count };

--- a/src/yellow-pages/yellow-pages.service.ts
+++ b/src/yellow-pages/yellow-pages.service.ts
@@ -115,10 +115,16 @@ export class YellowPagesService {
         provinceId: filterYellowPagesInput.province,
       });
     }
-    
+
     if (filterYellowPagesInput.district) {
       sqlQuery.andWhere('address.district = :districtId', {
         districtId: filterYellowPagesInput.district,
+      });
+    }
+
+    if (filterYellowPagesInput.is_emergency) {
+      sqlQuery.andWhere('phone_number.is_emergency = :isEmergency', {
+        isEmergency: filterYellowPagesInput.is_emergency,
       });
     }
 

--- a/src/yellow-pages/yellow-pages.service.ts
+++ b/src/yellow-pages/yellow-pages.service.ts
@@ -66,7 +66,6 @@ export class YellowPagesService {
     if (filterYellowPagesInput.category) {
       whereOptions.category = { id: filterYellowPagesInput.category };
     }
-
     if (filterYellowPagesInput.province | filterYellowPagesInput.district) {
       whereOptions.address = {
         province: { id: filterYellowPagesInput.province },
@@ -111,10 +110,13 @@ export class YellowPagesService {
       });
     }
 
-    if (filterYellowPagesInput.province | filterYellowPagesInput.district) {
+    if (filterYellowPagesInput.province) {
       sqlQuery.andWhere('address.province = :provinceId', {
         provinceId: filterYellowPagesInput.province,
       });
+    }
+    
+    if (filterYellowPagesInput.district) {
       sqlQuery.andWhere('address.district = :districtId', {
         districtId: filterYellowPagesInput.district,
       });


### PR DESCRIPTION
- Added search for yellow pages based on yellow pages name and yellow pages category name
- Implemented separate filtering for province and district i.e filtering can now be done by passing province only or district only in findAllSearch query.
- Added is_emergency to the filterInput to filter yellow pages based on emergency numbers

fixes #101 